### PR TITLE
include full name in apple auth response

### DIFF
--- a/Sources/SocialAuthentication/AppleAuthentication/AppleAuthentication.swift
+++ b/Sources/SocialAuthentication/AppleAuthentication/AppleAuthentication.swift
@@ -32,7 +32,7 @@ extension AppleAuthentication {
         
         let appleIdProvider = ASAuthorizationAppleIDProvider()
         let request = appleIdProvider.createRequest()
-        request.requestedScopes = [.email]
+        request.requestedScopes = [.email, .fullName]
         
         let authorizationController = ASAuthorizationController(authorizationRequests: [request])
         authorizationController.delegate = self
@@ -145,6 +145,7 @@ extension AppleAuthentication: ASAuthorizationControllerDelegate {
         let response = AppleAuthenticationResponse(
             authorizationCode: appleIdCredential.authorizationCode?.base64EncodedString(),
             email: appleIdCredential.email,
+            fullName: appleIdCredential.fullName,
             identityToken: appleIdCredential.identityToken?.base64EncodedString(),
             userId: appleIdCredential.user
         )

--- a/Sources/SocialAuthentication/AppleAuthentication/AppleAuthenticationResponse.swift
+++ b/Sources/SocialAuthentication/AppleAuthentication/AppleAuthenticationResponse.swift
@@ -12,13 +12,15 @@ public struct AppleAuthenticationResponse {
     
     public let authorizationCode: String?
     public let email: String?
+    public let fullName: PersonNameComponents?
     public let identityToken: String?
     public let userId: String?
     
-    public init(authorizationCode: String?, email: String?, identityToken: String?, userId: String?) {
+    public init(authorizationCode: String?, email: String?, fullName: PersonNameComponents?, identityToken: String?, userId: String?) {
         
         self.authorizationCode = authorizationCode
         self.email = email
+        self.fullName = fullName
         self.identityToken = identityToken
         self.userId = userId
     }


### PR DESCRIPTION
We'll need to know the user's name for building the GodTools `AuthenticationProviderAccessToken`.