### PR TITLE
Add method to fetch the top most presented viewController

### DIFF
--- a/Example/SocialAuthenticationExample.xcodeproj/project.pbxproj
+++ b/Example/SocialAuthenticationExample.xcodeproj/project.pbxproj
@@ -123,7 +123,6 @@
 				4560F19529EEFD4E0002F341 /* SocialAuthenticationExample.entitlements */,
 				45613D1D29EEFF9F005BF287 /* Info.plist */,
 				45613D1229EEFDD8005BF287 /* App */,
-				45613D2229EF012E005BF287 /* Packages */,
 				4560F19629EEFD4E0002F341 /* Preview Content */,
 			);
 			path = SocialAuthenticationExample;
@@ -179,13 +178,6 @@
 				455B4CC22A096FD90006AED5 /* Subviews */,
 			);
 			path = SignInWithSocial;
-			sourceTree = "<group>";
-		};
-		45613D2229EF012E005BF287 /* Packages */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Packages;
 			sourceTree = "<group>";
 		};
 		45613D2329EF0147005BF287 /* Packages */ = {

--- a/Sources/SocialAuthentication/AppleAuthentication/AppleAuthenticationState.swift
+++ b/Sources/SocialAuthentication/AppleAuthentication/AppleAuthenticationState.swift
@@ -3,6 +3,7 @@
 //  SocialAuthentication
 //
 //  Created by Rachael Skeath on 5/5/23.
+//  Copyright © 2023 Cru Global, Inc. All rights reserved.
 //
 
 import Foundation

--- a/Sources/SocialAuthentication/FacebookAuthentication/FacebookAuthentication.swift
+++ b/Sources/SocialAuthentication/FacebookAuthentication/FacebookAuthentication.swift
@@ -53,7 +53,9 @@ extension FacebookAuthentication {
     
     public func authenticate(from viewController: UIViewController, completion: @escaping ((_ result: Result<FacebookAuthenticationResponse, Error>) -> Void)) {
                
-        facebookLoginManager.logIn(permissions: configuration.permissions, from: viewController, handler: { (loginResult: LoginManagerLoginResult?, loginError: Error?) in
+        let authenticateFromViewController: UIViewController = viewController.getTopMostPresentedViewController() ?? viewController
+        
+        facebookLoginManager.logIn(permissions: configuration.permissions, from: authenticateFromViewController, handler: { (loginResult: LoginManagerLoginResult?, loginError: Error?) in
             
             if let loginResult = loginResult {
                 

--- a/Sources/SocialAuthentication/GoogleAuthentication/GoogleAuthentication.swift
+++ b/Sources/SocialAuthentication/GoogleAuthentication/GoogleAuthentication.swift
@@ -27,7 +27,9 @@ extension GoogleAuthentication {
     
     public func authenticate(from viewController: UIViewController, completion: @escaping ((_ result: Result<GoogleAuthenticationResponse, Error>) -> Void)) {
         
-        sharedGoogleSignIn.signIn(withPresenting: viewController, hint: nil, additionalScopes: nil, completion: { [weak self] (result: GIDSignInResult?, signInError: Error?) in
+        let authenticateFromViewController: UIViewController = viewController.getTopMostPresentedViewController() ?? viewController
+        
+        sharedGoogleSignIn.signIn(withPresenting: authenticateFromViewController, hint: nil, additionalScopes: nil, completion: { [weak self] (result: GIDSignInResult?, signInError: Error?) in
             
             if let signInError = signInError {
                 

--- a/Sources/SocialAuthentication/Share/Extensions/UIViewController+TopMostPresentedViewController.swift
+++ b/Sources/SocialAuthentication/Share/Extensions/UIViewController+TopMostPresentedViewController.swift
@@ -1,0 +1,28 @@
+//
+//  UIViewController+TopMostPresentedViewController.swift
+//  
+//
+//  Created by Levi Eggert on 5/17/23.
+//
+
+import UIKit
+
+extension UIViewController {
+    
+    func getTopMostPresentedViewController() -> UIViewController? {
+        
+        var nextTopMostPresentedViewController: UIViewController? = self
+        var topMostPresentedViewController: UIViewController?
+        
+        while nextTopMostPresentedViewController != nil {
+            
+            nextTopMostPresentedViewController = nextTopMostPresentedViewController?.presentedViewController
+            
+            if nextTopMostPresentedViewController != nil {
+                topMostPresentedViewController = nextTopMostPresentedViewController
+            }
+        }
+        
+        return topMostPresentedViewController
+    }
+}

--- a/Sources/SocialAuthentication/Share/Extensions/UIViewController+TopMostPresentedViewController.swift
+++ b/Sources/SocialAuthentication/Share/Extensions/UIViewController+TopMostPresentedViewController.swift
@@ -1,8 +1,9 @@
 //
 //  UIViewController+TopMostPresentedViewController.swift
-//  
+//  SocialAuthentication
 //
 //  Created by Levi Eggert on 5/17/23.
+//  Copyright © 2023 Cru Global, Inc. All rights reserved.
 //
 
 import UIKit


### PR DESCRIPTION
I needed to add a method that attempts to fetch the top most presented view controller on the provided viewController for facebook and google authentication since they internally present a viewController.  Presentation will fail if we provide a viewController that is already presenting a viewController, so instead fetch the top most presented viewController and present facebook and google from there.