### PR TITLE
Add methods for fetching Facebook and Google user profile info

### DIFF
--- a/Example/SocialAuthenticationExample/App/Features/SignInWithSocial/SignInWithSocialView.swift
+++ b/Example/SocialAuthenticationExample/App/Features/SignInWithSocial/SignInWithSocialView.swift
@@ -29,6 +29,12 @@ struct SignInWithSocialView: View {
                     .multilineTextAlignment(.center)
                     .padding(EdgeInsets(top: 50, leading: 30, bottom: 0, trailing: 30))
                 
+                Text("User name: \(viewModel.userName)")
+                    .font(Font.system(size: 17))
+                    .foregroundColor(Color.black)
+                    .multilineTextAlignment(.leading)
+                    .padding(EdgeInsets(top: 10, leading: 30, bottom: 0, trailing: 30))
+                
                 SocialSignInStatusView(
                     title: "Facebook has persisted access token: ",
                     isSuccessStatus: viewModel.facebookHasPersistedAccessToken

--- a/Example/SocialAuthenticationExample/App/Features/SignInWithSocial/SignInWithSocialViewModel.swift
+++ b/Example/SocialAuthenticationExample/App/Features/SignInWithSocial/SignInWithSocialViewModel.swift
@@ -21,6 +21,7 @@ class SignInWithSocialViewModel: ObservableObject {
     @Published var facebookHasPersistedAccessToken: Bool = false
     @Published var appleIsAuthenticated: Bool = false
     @Published var googleIsAuthenticated: Bool = false
+    @Published var userName: String = ""
     
     init(socialAuthPresenter: UIViewController, facebookAuthentication: FacebookAuthentication, appleAuthentication: AppleAuthentication, googleAuthentication: GoogleAuthentication) {
         
@@ -63,32 +64,32 @@ extension SignInWithSocialViewModel {
     
     func signInWithFacebookTapped() {
         
-        facebookAuthentication.authenticate(from: socialAuthPresenter) { (result: Result<FacebookAuthenticationResponse, Error>) in
-                        
-            print("finished")
+        facebookAuthentication.authenticate(from: socialAuthPresenter) { [weak self] (result: Result<FacebookAuthenticationResponse, Error>) in
+                                    
+            self?.userName = self?.facebookAuthentication.getCurrentUserProfile()?.name ?? ""
         }
     }
     
     func signInWithGoogleTapped() {
         
-        googleAuthentication.authenticate(from: socialAuthPresenter) { (result: Result<GoogleAuthenticationResponse, Error>) in
+        googleAuthentication.authenticate(from: socialAuthPresenter) { [weak self] (result: Result<GoogleAuthenticationResponse, Error>) in
             
-            switch result {
-                
-            case .success(let response):
-                break
-                
-            case .failure(let error):
-                break
-            }
+            self?.userName = self?.googleAuthentication.getCurrentUserProfile()?.name ?? ""
         }
     }
     
     func signInWithAppleTapped() {
         
-        appleAuthentication.authenticate { _ in
+        appleAuthentication.authenticate { [weak self] (result: Result<AppleAuthenticationResponse, Error>) in
             
-            print("finished")
+            switch result {
+           
+            case .success(let response):
+                self?.userName = response.fullName?.familyName ?? ""
+                
+            case .failure( _):
+                break
+            }
         }
     }
 }

--- a/Sources/SocialAuthentication/FacebookAuthentication/FacebookAuthentication+Combine.swift
+++ b/Sources/SocialAuthentication/FacebookAuthentication/FacebookAuthentication+Combine.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import FBSDKLoginKit
 import Combine
 
 public extension FacebookAuthentication {
@@ -55,5 +56,30 @@ public extension FacebookAuthentication {
         
         return Just(())
             .eraseToAnyPublisher()
+    }
+    
+    func getCurrentUserProfilePublisher() -> AnyPublisher<Profile?, Never> {
+        
+        let profile: Profile? = getCurrentUserProfile()
+        
+        return Just(profile)
+            .eraseToAnyPublisher()
+    }
+    
+    func loadUserProfilePublisher() -> AnyPublisher<Profile?, Error> {
+        
+        return Future() { promise in
+                    
+            Profile.loadCurrentProfile { (profile: Profile?, error: Error?) in
+                
+                if let error = error {
+                    promise(.failure(error))
+                }
+                else {
+                    promise(.success(profile))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
     }
 }

--- a/Sources/SocialAuthentication/FacebookAuthentication/FacebookAuthentication.swift
+++ b/Sources/SocialAuthentication/FacebookAuthentication/FacebookAuthentication.swift
@@ -36,6 +36,10 @@ public class FacebookAuthentication: NSObject {
         NotificationCenter.default.removeObserver(self, name: .AccessTokenDidChange, object: nil)
     }
     
+    public func getLoginManager() -> LoginManager {
+        return facebookLoginManager
+    }
+    
     public var accessTokenChangedPublisher: AnyPublisher<String?, Never> {
         return accessTokenChanged
             .eraseToAnyPublisher()
@@ -122,5 +126,19 @@ extension FacebookAuthentication {
     public func signOut() {
         
         facebookLoginManager.logOut()
+    }
+}
+
+// MARK: - User
+
+extension FacebookAuthentication {
+    
+    public func getCurrentUserProfile() -> Profile? {
+        return Profile.current
+    }
+    
+    public func loadUserProfile(completion: @escaping ((_ profile: Profile?, _ error: Error?) -> Void)) {
+        
+        Profile.loadCurrentProfile(completion: completion)
     }
 }

--- a/Sources/SocialAuthentication/GoogleAuthentication/GoogleAuthentication+Combine.swift
+++ b/Sources/SocialAuthentication/GoogleAuthentication/GoogleAuthentication+Combine.swift
@@ -76,4 +76,20 @@ public extension GoogleAuthentication {
         return Just(())
             .eraseToAnyPublisher()
     }
+    
+    func getCurrentUserPublisher() -> AnyPublisher<GIDGoogleUser?, Never> {
+        
+        let user: GIDGoogleUser? = getCurrentUser()
+        
+        return Just(user)
+            .eraseToAnyPublisher()
+    }
+    
+    func getCurrentUserProfilePublisher() -> AnyPublisher<GIDProfileData?, Never> {
+        
+        let profile: GIDProfileData? = getCurrentUserProfile()
+        
+        return Just(profile)
+            .eraseToAnyPublisher()
+    }
 }

--- a/Sources/SocialAuthentication/GoogleAuthentication/GoogleAuthentication.swift
+++ b/Sources/SocialAuthentication/GoogleAuthentication/GoogleAuthentication.swift
@@ -19,6 +19,10 @@ public class GoogleAuthentication {
             clientID: configuration.clientId
         )
     }
+    
+    public func getGoogleSignIn() -> GIDSignIn {
+        return sharedGoogleSignIn
+    }
 }
 
 // MARK: - Authenticate
@@ -83,10 +87,6 @@ extension GoogleAuthentication {
 
 extension GoogleAuthentication {
     
-    public func getCurrentUser() -> GIDGoogleUser? {
-        return sharedGoogleSignIn.currentUser
-    }
-    
     public func getPersistedIdTokenString() -> String? {
         return getCurrentUser()?.idToken?.tokenString
     }
@@ -131,5 +131,18 @@ extension GoogleAuthentication {
     public func signOut() {
         
         sharedGoogleSignIn.signOut()
+    }
+}
+
+// MARK:  User
+
+extension GoogleAuthentication {
+    
+    public func getCurrentUser() -> GIDGoogleUser? {
+        return sharedGoogleSignIn.currentUser
+    }
+    
+    public func getCurrentUserProfile() -> GIDProfileData? {
+        return getCurrentUser()?.profile
     }
 }


### PR DESCRIPTION
Changes in this PR:
- Add methods to Facebook and Google to expose current signed in user information.
- Expose shared GIDSignIn and LoginManager on GoogleAuthentication and FacebookAuthentication.