### PR TITLE
Add GoogleSignIn server client id to config

### DIFF
--- a/SocialAuthentication.podspec
+++ b/SocialAuthentication.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'SocialAuthentication'
-    s.version          = '0.2.2'
+    s.version          = '0.3.0'
     s.summary          = 'Module for obtaining access tokens from social platforms FacebookLogin, GoogleSignIn, and AppleSignIn.'
   
   

--- a/Sources/SocialAuthentication/GoogleAuthentication/GoogleAuthentication.swift
+++ b/Sources/SocialAuthentication/GoogleAuthentication/GoogleAuthentication.swift
@@ -14,9 +14,12 @@ public class GoogleAuthentication {
     private let sharedGoogleSignIn: GIDSignIn = GIDSignIn.sharedInstance
     
     public init(configuration: GoogleAuthenticationConfiguration) {
-        
+                
         sharedGoogleSignIn.configuration = GIDConfiguration.init(
-            clientID: configuration.clientId
+            clientID: configuration.clientId,
+            serverClientID: configuration.serverClientId,
+            hostedDomain: configuration.hostedDomain,
+            openIDRealm: configuration.openIDRealm
         )
     }
     

--- a/Sources/SocialAuthentication/GoogleAuthentication/GoogleAuthenticationConfiguration.swift
+++ b/Sources/SocialAuthentication/GoogleAuthentication/GoogleAuthenticationConfiguration.swift
@@ -11,9 +11,15 @@ import Foundation
 public class GoogleAuthenticationConfiguration {
     
     public let clientId: String
+    public let serverClientId: String?
+    public let hostedDomain: String?
+    public let openIDRealm: String?
     
-    public init(clientId: String) {
+    public init(clientId: String, serverClientId: String?, hostedDomain: String?, openIDRealm: String?) {
         
         self.clientId = clientId
+        self.serverClientId = serverClientId
+        self.hostedDomain = hostedDomain
+        self.openIDRealm = openIDRealm
     }
 }


### PR DESCRIPTION
Hey @rachaelblue I also need to include the serverClientId for google sign-in configuration.  This is the clientId Daniel was just talking about.