### PR TITLE
Update apple auth identity and auth code encode

### DIFF
--- a/Example/SocialAuthenticationExample/App/AppDelegate.swift
+++ b/Example/SocialAuthenticationExample/App/AppDelegate.swift
@@ -44,7 +44,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             ),
             googleAuthentication: GoogleAuthentication(
                 configuration: GoogleAuthenticationConfiguration(
-                    clientId: "71275134527-st5s63prkvuh46t7ohb1gmhq39qokh78.apps.googleusercontent.com"
+                    clientId: "71275134527-st5s63prkvuh46t7ohb1gmhq39qokh78.apps.googleusercontent.com",
+                    serverClientId: nil,
+                    hostedDomain: nil,
+                    openIDRealm: nil
                 )
             )
         )

--- a/SocialAuthentication.podspec
+++ b/SocialAuthentication.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'SocialAuthentication'
-    s.version          = '0.3.0'
+    s.version          = '0.3.1'
     s.summary          = 'Module for obtaining access tokens from social platforms FacebookLogin, GoogleSignIn, and AppleSignIn.'
   
   

--- a/Sources/SocialAuthentication/AppleAuthentication/ASAuthorizationAppleIDCredential+Data.swift
+++ b/Sources/SocialAuthentication/AppleAuthentication/ASAuthorizationAppleIDCredential+Data.swift
@@ -1,0 +1,31 @@
+//
+//  ASAuthorizationAppleIDCredential+Data.swift
+//  SocialAuthentication
+//
+//  Created by Levi Eggert on 4/18/23.
+//  Copyright © 2023 Cru Global, Inc. All rights reserved.
+//
+
+import Foundation
+import AuthenticationServices
+
+extension ASAuthorizationAppleIDCredential {
+    
+    public func getAuthorizationCodeString() -> String? {
+        
+        guard let authorizationCode = authorizationCode else {
+            return nil
+        }
+        
+        return String(data: authorizationCode, encoding: .utf8)
+    }
+    
+    public func getIdentityTokenString() -> String? {
+        
+        guard let identityToken = identityToken else {
+            return nil
+        }
+        
+        return String(data: identityToken, encoding: .utf8)
+    }
+}

--- a/Sources/SocialAuthentication/AppleAuthentication/AppleAuthentication.swift
+++ b/Sources/SocialAuthentication/AppleAuthentication/AppleAuthentication.swift
@@ -118,10 +118,10 @@ extension AppleAuthentication: ASAuthorizationControllerDelegate {
         let userId = appleIdCredential.user
         
         let response = AppleAuthenticationResponse(
-            authorizationCode: appleIdCredential.authorizationCode?.base64EncodedString(),
+            authorizationCode: appleIdCredential.getAuthorizationCodeString(),
             email: email,
             fullName: fullName,
-            identityToken: appleIdCredential.identityToken?.base64EncodedString(),
+            identityToken: appleIdCredential.getIdentityTokenString(),
             userId: userId
         )
         


### PR DESCRIPTION
Change identity and auth code encoding to utf8.  I noticed the Apple docs mentions the auth code and identity token are encoded using NSUTF8StringEncoding (https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential/3153032-authorizationcode).  I'm guessing originally they were utf8 before converting to Data types.