### PR TITLE
Fix to apple authentication

### DIFF
--- a/Sources/SocialAuthentication/AppleAuthentication/AppleAuthorization.swift
+++ b/Sources/SocialAuthentication/AppleAuthentication/AppleAuthorization.swift
@@ -32,10 +32,9 @@ public final class AppleAuthorization: NSObject {
         request.requestedScopes = requestScopes
         
         let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authController = authorizationController
         authorizationController.delegate = self
         authorizationController.performRequests()
-        
-        authController = authorizationController
     }
     
     public var isAuthenticating: Bool {

--- a/Sources/SocialAuthentication/AppleAuthentication/AppleAuthorization.swift
+++ b/Sources/SocialAuthentication/AppleAuthentication/AppleAuthorization.swift
@@ -13,11 +13,19 @@ public final class AppleAuthorization: NSObject {
     
     public typealias AppleAuthenticationCompletion = ((_ result: Result<AppleAuthenticationResponse, Error>) -> Void)
     
+    private var authController: ASAuthorizationController?
     private var completionBlock: AppleAuthenticationCompletion?
     
     public func authenticate(requestScopes: [ASAuthorization.Scope], completion: @escaping AppleAuthenticationCompletion) {
         
-        self.completionBlock = completion
+        if let authController = authController {
+            completionBlock = nil
+            authController.delegate = nil
+            authController.cancel()
+            self.authController = nil
+        }
+        
+        completionBlock = completion
         
         let appleIdProvider = ASAuthorizationAppleIDProvider()
         let request = appleIdProvider.createRequest()
@@ -26,6 +34,27 @@ public final class AppleAuthorization: NSObject {
         let authorizationController = ASAuthorizationController(authorizationRequests: [request])
         authorizationController.delegate = self
         authorizationController.performRequests()
+        
+        authController = authorizationController
+    }
+    
+    public var isAuthenticating: Bool {
+        return authController != nil
+    }
+    
+    public func cancelAuthenication() {
+        
+        guard let authController = authController else {
+            return
+        }
+        
+        authController.cancel()
+    }
+    
+    private func destroyAuthControllerReferences() {
+        completionBlock = nil
+        authController?.delegate = nil
+        authController = nil
     }
 }
 
@@ -38,6 +67,8 @@ extension AppleAuthorization: ASAuthorizationControllerDelegate {
         guard let completion = completionBlock else {
             return
         }
+        
+        destroyAuthControllerReferences()
         
         let errorCode: Int = (error as NSError).code
         
@@ -57,8 +88,10 @@ extension AppleAuthorization: ASAuthorizationControllerDelegate {
             return
         }
         
+        destroyAuthControllerReferences()
+        
         guard let appleIdCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
-            
+                        
             completion(.failure(AppleAuthenticationError.noAuthCredential))
             return
         }


### PR DESCRIPTION
Remove reference to closure once apple auth completes
Cancel current apple auth if called during auth